### PR TITLE
fix: no-ticket Error message

### DIFF
--- a/src/Results.js
+++ b/src/Results.js
@@ -27,7 +27,9 @@ export default function Results({ response, error }) {
             ...inspectorTheme,
             OBJECT_VALUE_STRING_COLOR: 'red',
         };
-        obj = error;
+        if (typeof error !== 'boolean') {
+            obj = error;
+        }
     } else {
         dynamicInspectorTheme = {
             ...inspectorTheme,


### PR DESCRIPTION
Seems like failing grpc service returns `error` as boolean instead of a message. The error message itself is in `response`. Added type check so it's not just showing `true` when grpc fails. In case `error` is not a boolean but some error message it will work as it used to be.

Before:
<img width="1141" alt="Screenshot 2023-03-28 at 14 47 45" src="https://user-images.githubusercontent.com/6786523/228227165-19cb70a5-b564-4a2a-8d23-96200bdff37f.png">
After:
<img width="1160" alt="Screenshot 2023-03-28 at 14 47 22" src="https://user-images.githubusercontent.com/6786523/228227200-55f8d6e8-ce54-4c4e-b221-018eba583751.png">
